### PR TITLE
Fixed documentation error and re-organised dependencies inline with dart best practices.

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
     source: sdk
     version: "0.0.0"
   http:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       name: http
       sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
@@ -92,36 +92,36 @@ packages:
     source: hosted
     version: "4.0.2"
   june:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.8.8"
+    version: "1.0.0+1"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -150,10 +150,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
@@ -211,10 +211,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -235,10 +235,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:
@@ -249,3 +249,4 @@ packages:
     version: "0.5.1"
 sdks:
   dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -21,13 +21,9 @@ version: 1.0.0+1
 environment:
   sdk: '>=3.2.6 <4.0.0'
 
-dependency_overrides:
-  june:
-    path: ../
-  http: ^1.2.1
-
-
 dependencies:
+  june:
+  http: ^1.2.1
   flutter:
     sdk: flutter
 

--- a/example/pubspec_overrides.yaml
+++ b/example/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  june:
+    path: ../

--- a/lib/state_manager/src/simple/controllers.dart
+++ b/lib/state_manager/src/simple/controllers.dart
@@ -7,7 +7,7 @@ import 'list_notifier.dart';
 
 // ignore: prefer_mixin
 abstract class JuneState extends ListNotifier with JuneLifeCycleMixin {
-  /// Rebuilds `JuneBuilder` each time you call `update()`;
+  /// Rebuilds `JuneBuilder` each time you call `setState()`;
   /// Can take a List of [ids], that will only update the matching
   /// `JuneBuilder( id: )`,
   /// [ids] can be reused among `JuneBuilders` like group tags.

--- a/lib/state_manager/src/simple/simple_builder.dart
+++ b/lib/state_manager/src/simple/simple_builder.dart
@@ -30,12 +30,12 @@ class StateBuilder<T> extends StatefulWidget {
   final void Function(T)? onUpdate;
 
   const StateBuilder({
-    Key? key,
+    super.key,
     required this.initialValue,
     this.onDispose,
     this.onUpdate,
     required this.builder,
-  }) : super(key: key);
+  });
 
   @override
   StateBuilderState<T> createState() => StateBuilderState<T>();
@@ -80,7 +80,7 @@ class ObxElement = StatelessElement with StatelessObserverComponent;
 class Observer extends ObxStatelessWidget {
   final WidgetBuilder builder;
 
-  const Observer({Key? key, required this.builder}) : super(key: key);
+  const Observer({super.key, required this.builder});
 
   @override
   Widget build(BuildContext context) => builder(context);
@@ -89,7 +89,7 @@ class Observer extends ObxStatelessWidget {
 /// A StatelessWidget than can listen reactive changes.
 abstract class ObxStatelessWidget extends StatelessWidget {
   /// Initializes [key] for subclasses.
-  const ObxStatelessWidget({Key? key}) : super(key: key);
+  const ObxStatelessWidget({super.key});
 
   @override
   StatelessElement createElement() => ObxElement(this);

--- a/lib/state_manager/src/simple/state.dart
+++ b/lib/state_manager/src/simple/state.dart
@@ -53,7 +53,7 @@ class JuneBuilder<T extends JuneState> extends StatelessWidget {
 
   const JuneBuilder(
     this._creator, {
-    Key? key,
+    super.key,
     this.init,
     this.global = true,
     required this.builder,
@@ -66,7 +66,7 @@ class JuneBuilder<T extends JuneState> extends StatelessWidget {
     this.id,
     this.didChangeDependencies,
     this.didUpdateWidget,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -96,7 +96,7 @@ class JuneBuilder<T extends JuneState> extends StatelessWidget {
 
 abstract class Bind<T> extends StatelessWidget {
   const Bind({
-    Key? key,
+    super.key,
     required this.child,
     this.init,
     this.global = true,
@@ -109,7 +109,7 @@ abstract class Bind<T> extends StatelessWidget {
     this.id,
     this.didChangeDependencies,
     this.didUpdateWidget,
-  }) : super(key: key);
+  });
 
   final InitBuilder<T>? init;
 
@@ -304,7 +304,7 @@ class _FactoryBind<T> extends Bind<T> {
   final Widget? child;
 
   const _FactoryBind({
-    Key? key,
+    super.key,
     this.child,
     this.init,
     this.create,
@@ -318,7 +318,7 @@ class _FactoryBind<T> extends Bind<T> {
     this.id,
     this.didChangeDependencies,
     this.didUpdateWidget,
-  }) : super(key: key, child: child);
+  }) : super(child: child);
 
   @override
   Bind<T> _copyWithChild(Widget child) {
@@ -363,11 +363,10 @@ class Binds extends StatelessWidget {
   final Widget child;
 
   Binds({
-    Key? key,
+    super.key,
     required this.binds,
     required this.child,
-  })  : assert(binds.isNotEmpty),
-        super(key: key);
+  }) : assert(binds.isNotEmpty);
 
   @override
   Widget build(BuildContext context) =>
@@ -380,8 +379,8 @@ class Binder<T> extends InheritedWidget {
   ///
   /// The [child] argument is required
   const Binder({
-    Key? key,
-    required Widget child,
+    super.key,
+    required super.child,
     this.init,
     this.global = true,
     this.autoRemove = true,
@@ -395,7 +394,7 @@ class Binder<T> extends InheritedWidget {
     this.didChangeDependencies,
     this.didUpdateWidget,
     this.create,
-  }) : super(key: key, child: child);
+  });
 
   final InitBuilder<T>? init;
   final InstanceCreateBuilderCallback? create;
@@ -427,7 +426,7 @@ class Binder<T> extends InheritedWidget {
 /// The BindElement is responsible for injecting dependencies into the widget
 /// tree so that they can be observed
 class BindElement<T> extends InheritedElement {
-  BindElement(Binder<T> widget) : super(widget) {
+  BindElement(Binder<T> super.widget) {
     initState();
   }
 

--- a/lib/state_manager/src/simple/widget_cache.dart
+++ b/lib/state_manager/src/simple/widget_cache.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 abstract class JuneWidgetCache extends Widget {
-  const JuneWidgetCache({Key? key}) : super(key: key);
+  const JuneWidgetCache({super.key});
 
   @override
   JuneWidgetCacheElement createElement() => JuneWidgetCacheElement(this);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  flutter_lints:
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
Fixed example package dependences - moved the relative path override into pubspec_overrides.yaml which is where dart no recommends over-rides go. Fixed documenation on controllers.setState which referred to the old name 'update'. Corrected a number of minor lint erros.